### PR TITLE
add start hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,60 @@
 # bfx-facs-base
 
-git clone https://github.com/bitfinexcom/REPO.git REPO
+## bootstrap hooks
 
-git remote -v
+Some facilities need special setup before other facilites are started. By default,
+the bfx-facs-grc, which announces the service to the Grape network is started
+later than the other facs.
 
-git remote add upstream https://github.com/bitfinexcom/PARENT.git
+To run special setup or cleanup tasks before other facs start, use the `start`
+option:
 
-git remote -v
+```js
+const opts = {
+  start: (inst, cb) => {
+    console.log(inst.db) // do async stuff here
+    cb(null)
+  }
+}
+this.setInitFacs([
+  ['fac', 'bfx-facs-db-mongo', 'm0', 'm0', opts]
+])
+```
 
-git push origin master
+Example:
+
+On service start, this will print:
+
+```
+bfx-facs-first start hook
+bfx-facs-second start hook
+start0 executed
+```
+
+```js
+class WrkUtilNetApi extends WrkApi {
+  init () {
+    super.init()
+
+    this.setInitFacs([
+      ['fac', 'bfx-facs-first', 'm0', 'm0', {
+        start: (inst, cb) => {
+          console.log('bfx-facs-first start hook')
+          cb(null)
+        }
+      }, 0], // prio: 0 (default)
+      ['fac', 'bfx-facs-second', 'm0', 'm0', {
+        start: (inst, cb) => {
+          console.log('bfx-facs-second start hook')
+          cb(null)
+        }
+      }, 1], // prio 1
+    ])
+  }
+
+  _start0 (cb) {
+    console.log('start0 executed')
+    cb(null)
+  }
+}
+```

--- a/base.js
+++ b/base.js
@@ -43,6 +43,15 @@ class Facility extends EventEmitter {
       },
       next => {
         this._start(next)
+      },
+      next => {
+        const start = this.opts.start
+        if (!start) return next()
+        if (typeof start !== 'function') {
+          return next(new Error('opts.start must be of type function'))
+        }
+
+        start(this, next)
       }
     ], cb)
   }


### PR DESCRIPTION
Some facilities need special setup before other facilites are
started. By default, the bfx-facs-grc, which announces the service
to the Grape network is started later than the other facs.

This PR adds a `start` option to run async tasks before other
facs are started.

Example:

On service start, this will print:

```
bfx-facs-first start hook
bfx-facs-second start hook
start0 executed
```

```js
class WrkUtilNetApi extends WrkApi {
  init () {
    super.init()

    this.setInitFacs([
      ['fac', 'bfx-facs-first', 'm0', 'm0', {
        start: (inst, cb) => {
          console.log('bfx-facs-first start hook')
          cb(null)
        }
      }, 0], // prio: 0 (default)
      ['fac', 'bfx-facs-second', 'm0', 'm0', {
        start: (inst, cb) => {
          console.log('bfx-facs-second start hook')
          cb(null)
        }
      }, 1], // prio 1
    ])
  }

  _start0 (cb) {
    console.log('start0 executed')
    cb(null)
  }
}
```