### PR TITLE
adjusted config load to check for test prefix

### DIFF
--- a/base.js
+++ b/base.js
@@ -20,7 +20,7 @@ class Facility extends EventEmitter {
     if (this._hasConf) {
       const cal = this.caller
 
-      const fprefix = this.ctx.env === 'test' ? 'test' : ''
+      const fprefix = this.ctx.env
       const dirname = path.join(cal.ctx.root, 'config', 'facs')
 
       let confpath = path.join(dirname, `${this.name}.config.json`)

--- a/base.js
+++ b/base.js
@@ -74,7 +74,7 @@ class Facility extends EventEmitter {
         this.active = 0
         if (!this.working) return next()
 
-        let itv = setInterval(() => {
+        const itv = setInterval(() => {
           if (this.working) return
           clearInterval(itv)
           next()

--- a/base.js
+++ b/base.js
@@ -2,6 +2,7 @@
 
 const EventEmitter = require('events')
 const fs = require('fs')
+const path = require('path')
 const _ = require('lodash')
 const async = require('async')
 
@@ -19,11 +20,16 @@ class Facility extends EventEmitter {
     if (this._hasConf) {
       const cal = this.caller
 
-      const conf = JSON.parse(
-        fs.readFileSync(
-          `${cal.ctx.root}/config/facs/${this.name}.config.json`, 'utf8'
-        )
-      )
+      const fprefix = this.ctx.env === 'test' ? 'test' : ''
+      const dirname = path.join(cal.ctx.root, 'config', 'facs')
+
+      let confpath = path.join(dirname, `${this.name}.config.json`)
+      const testpath = path.join(dirname, `${fprefix}.${this.name}.config.json`)
+      if (fprefix && fs.existsSync(testpath)) {
+        confpath = testpath
+      }
+
+      const conf = JSON.parse(fs.readFileSync(confpath, 'utf8'))
       this.conf = conf[this.opts.ns]
     }
   }

--- a/base.js
+++ b/base.js
@@ -23,13 +23,13 @@ class Facility extends EventEmitter {
       const fprefix = this.ctx.env
       const dirname = path.join(cal.ctx.root, 'config', 'facs')
 
-      let confpath = path.join(dirname, `${this.name}.config.json`)
-      const testpath = path.join(dirname, `${fprefix}.${this.name}.config.json`)
-      if (fprefix && fs.existsSync(testpath)) {
-        confpath = testpath
+      let confPath = path.join(dirname, `${this.name}.config.json`)
+      const envConfPath = path.join(dirname, `${fprefix}.${this.name}.config.json`)
+      if (fprefix && fs.existsSync(envConfPath)) {
+        confPath = envConfPath
       }
 
-      const conf = JSON.parse(fs.readFileSync(confpath, 'utf8'))
+      const conf = JSON.parse(fs.readFileSync(confPath, 'utf8'))
       this.conf = conf[this.opts.ns]
     }
   }


### PR DESCRIPTION
### Description

This PR adds support for `test.<facname>.config.json` files that would be loaded in case if `env` is `test`

### Usage

Let's say we have a worker that fetches some data from a specific api, if we use env based approach we could have config files like this:

```
configs/facs/some-fac.config.json
{ "main": { "api": "https://api.myapi.com/v2..." } }

configs/facs/development.some-fac.config.json
{ "main": { "api": "https://api.staging.myapi.com/v2..." } }

configs/facs/test.some-fac.config.json
{ "main": { "api": "http://localhost:3000/v2..." } }
```

And while testing the worker we need to see how it would work with real dataand some mock data,
in that case we would simply run worker with different `env` and we would switch to different apis easily