### PR TITLE
feat: add support for JS config files

### DIFF
--- a/base.js
+++ b/base.js
@@ -24,25 +24,13 @@ class Facility extends EventEmitter {
 
     const baseJsonPath = path.join(dirname, `${this.name}.config.json`)
     const envJsonPath = path.join(dirname, `${fprefix}.${this.name}.config.json`)
-
-    if (fprefix && fs.existsSync(envJsonPath)) {
-      return envJsonPath
-    }
-    if (fs.existsSync(baseJsonPath)) {
-      return baseJsonPath
-    }
-
     const baseJsPath = path.join(dirname, `${this.name}.config.js`)
     const envJsPath = path.join(dirname, `${fprefix}.${this.name}.config.js`)
 
-    if (fprefix && fs.existsSync(envJsPath)) {
-      return envJsPath
-    }
-    if (fs.existsSync(baseJsPath)) {
-      return baseJsPath
-    }
+    const candidates = [envJsonPath, baseJsonPath, envJsPath, baseJsPath]
+    const confPath = candidates.find(p => fs.existsSync(p)) || baseJsonPath
 
-    return baseJsonPath
+    return confPath
   }
 
   init () {

--- a/base.js
+++ b/base.js
@@ -22,10 +22,10 @@ class Facility extends EventEmitter {
     const fprefix = this.ctx.env
     const dirname = path.join(cal.ctx.root, 'config', 'facs')
 
-    const baseJsonPath = path.join(dirname, `${this.name}.config.json`)
     const envJsonPath = path.join(dirname, `${fprefix}.${this.name}.config.json`)
-    const baseJsPath = path.join(dirname, `${this.name}.config.js`)
+    const baseJsonPath = path.join(dirname, `${this.name}.config.json`)
     const envJsPath = path.join(dirname, `${fprefix}.${this.name}.config.js`)
+    const baseJsPath = path.join(dirname, `${this.name}.config.js`)
 
     const candidates = [envJsonPath, baseJsonPath, envJsPath, baseJsPath]
     const confPath = candidates.find(p => fs.existsSync(p)) || baseJsonPath

--- a/base.js
+++ b/base.js
@@ -22,18 +22,35 @@ class Facility extends EventEmitter {
     const fprefix = this.ctx.env
     const dirname = path.join(cal.ctx.root, 'config', 'facs')
 
-    let confPath = path.join(dirname, `${this.name}.config.json`)
-    const envConfPath = path.join(dirname, `${fprefix}.${this.name}.config.json`)
-    if (fprefix && fs.existsSync(envConfPath)) {
-      confPath = envConfPath
+    const baseJsonPath = path.join(dirname, `${this.name}.config.json`)
+    const envJsonPath = path.join(dirname, `${fprefix}.${this.name}.config.json`)
+
+    if (fprefix && fs.existsSync(envJsonPath)) {
+      return envJsonPath
     }
-    return confPath
+    if (fs.existsSync(baseJsonPath)) {
+      return baseJsonPath
+    }
+
+    const baseJsPath = path.join(dirname, `${this.name}.config.js`)
+    const envJsPath = path.join(dirname, `${fprefix}.${this.name}.config.js`)
+
+    if (fprefix && fs.existsSync(envJsPath)) {
+      return envJsPath
+    }
+    if (fs.existsSync(baseJsPath)) {
+      return baseJsPath
+    }
+
+    return baseJsonPath
   }
 
   init () {
     if (this._hasConf) {
       const confPath = this._getConfPath()
-      const conf = JSON.parse(fs.readFileSync(confPath, 'utf8'))
+      const conf = confPath.endsWith('.js')
+        ? require(confPath)
+        : JSON.parse(fs.readFileSync(confPath, 'utf8'))
       this.conf = conf[this.opts.ns]
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@bitfinex/bfx-facs-base",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitfinex/bfx-facs-base",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "async": "^3.2.1",
-        "lodash": "^4.17.21"
+        "lodash": "^4.18.1"
       },
       "devDependencies": {
         "brittle": "^3.19.1",
@@ -225,10 +225,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1110,10 +1111,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2187,10 +2189,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -3113,9 +3116,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -3145,10 +3149,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3977,6 +3982,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "eslint": "^8.41.0",
         "eslint-config-standard": "17.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
         "lodash": "^4.17.21"
       },
       "devDependencies": {
-        "standard": "^17.1.2"
+        "brittle": "^3.19.1",
+        "standard": "^17.1.2",
+        "test-tmp": "^1.4.0"
       },
       "engines": {
         "node": ">=16.0"
@@ -113,6 +115,34 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -153,6 +183,13 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -414,11 +451,663 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bare-abort": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/bare-abort/-/bare-abort-2.0.13.tgz",
+      "integrity": "sha512-zdc8l88eB11Jsz5rDd6sCAgv2kUFXgdrZWoMlgU6JMkfAi1/uuGFC3IEHswKbIRQTk5H3T5CMuechsXYxiaHlQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-addon-resolve": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.0.tgz",
+      "integrity": "sha512-sSd0jieRJlDaODOzj0oe0RjFVC1QI0ZIjGIdPkbrTXsdVVtENg14c+lHHAhHwmWCZ2nQlMhy8jA3Y5LYPc/isA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-module-resolve": "^1.10.0",
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-ansi-escapes": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/bare-ansi-escapes/-/bare-ansi-escapes-2.2.3.tgz",
+      "integrity": "sha512-02ES4/E2RbrtZSnHJ9LntBhYkLA6lPpSEeP8iqS3MccBIVhVBlEmruF1I7HZqx5Q8aiTeYfQVeqmrU9YO2yYoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-stream": "^2.6.5"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-assert": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bare-assert/-/bare-assert-1.2.0.tgz",
+      "integrity": "sha512-c6uvgvTJBspTDxtVnPgrBKmLgcpW3Fp72NVKDLg6oT4QjQbhGtvrkHMhGYMK1sh4vjBHOBmuUalyt9hSzV37fQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-inspect": "^3.1.2"
+      }
+    },
+    "node_modules/bare-bundle": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/bare-bundle/-/bare-bundle-1.10.0.tgz",
+      "integrity": "sha512-4LVlnJAHr00Hh6Vu6ZUJS38rcEtJT3b3vChXSsBsJ2mk1TN0lQ+gzd+Dw5L0aV7uqDZv84smuwW+O02X7PfDlw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-cov": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bare-cov/-/bare-cov-1.2.1.tgz",
+      "integrity": "sha512-SHNqb/WG9udUEj8m5qGSehoUQ9o0Xzv8nrf4HIdmG+KNU/XdhPLhTP5VPrHnSAMAXhAzEB4Q+2IYZ0x9qPzN1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.1.2",
+        "bare-inspector": "^4.0.1",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.2.1",
+        "bare-url": "^2.1.5",
+        "bare-v8-to-istanbul": "^1.0.2",
+        "picomatch": "^4.0.2",
+        "which-runtime": "^1.2.1"
+      }
+    },
+    "node_modules/bare-crypto": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/bare-crypto/-/bare-crypto-1.13.4.tgz",
+      "integrity": "sha512-JiCZ5l2YOG1y8J7yy1BCAKTCZrPnHLb7pDRIdurBTOn5oIwBQDIv8iH5Pl2V85vzjl1NZXRfNY4HZLsE942jJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-assert": "^1.2.0",
+        "bare-stream": "^2.6.3"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-debug-log": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bare-debug-log/-/bare-debug-log-2.0.0.tgz",
+      "integrity": "sha512-Vi42PkMQsNV9PUpx2Gl1hikshx5O9FzMJ6o9Nnopseg7qLBBK7Nl31d0RHcfwLEAfmcPApytpc0ZFfq68u22FQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-dns": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/bare-dns/-/bare-dns-2.1.4.tgz",
+      "integrity": "sha512-abwjHmpWqSRNB7V5615QxPH92L71AVzFm/kKTs8VYiNTAi2xVdonpv0BjJ0hwXLwomoW+xsSOPjW6PZPO14asg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.7.0"
+      }
+    },
+    "node_modules/bare-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bare-encoding/-/bare-encoding-1.0.3.tgz",
+      "integrity": "sha512-Kqf+t/azs13lUeyK4Tb7ha4wdLRXKWCXQ8w1rVmt7KtoPCPdHD/Xwt7LBIsCSwwGglrcmblo5VOLa5avkJqULA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-env": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-env/-/bare-env-3.0.0.tgz",
+      "integrity": "sha512-0u964P5ZLAxTi+lW4Kjp7YRJQ5gZr9ycYOtjLxsSrupgMz3sn5Z9n4SH/JIifHwvadsf1brA2JAjP+9IOWwTiw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-format": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bare-format/-/bare-format-1.0.2.tgz",
+      "integrity": "sha512-GswdhnOnP9QtwRbrf4wLApw5widkaLMsLe2XOs35fQD2YfEN1ApoGka+cZ7PfvzxMgfYXmMhj/2OGlVn5/Dxgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-inspect": "^3.0.0"
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-hrtime": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bare-hrtime/-/bare-hrtime-2.1.1.tgz",
+      "integrity": "sha512-VMb3tHo05gsnbu3OXTmkDiwTjMlOsbQmKoysKqKEyR09m77TuDrYFbj3Q5GGk10dAKsUHrnXmwCaeJqzVpB5ZA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-http-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/bare-http-parser/-/bare-http-parser-1.1.3.tgz",
+      "integrity": "sha512-+dhVvQi6brHq14L/XHNRQ+TLuVE76VjRmMt61wVEtS+Od8xUslfMHWJN/ZjIIt3RtTG6vPuA+x9cOh7KrkBJsA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-http1": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/bare-http1/-/bare-http1-4.5.6.tgz",
+      "integrity": "sha512-31OAwMkSU+z1VuUOCk65hx3aWQgzCfH/zQ6LGxbJtmiy2Czsw0+uvOBM9YkqaL6zUSTSYG2pLbL0v/TjME3Buw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.6.0",
+        "bare-http-parser": "^1.1.1",
+        "bare-stream": "^2.10.0",
+        "bare-tcp": "^2.2.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-https": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/bare-https/-/bare-https-2.1.3.tgz",
+      "integrity": "sha512-0TI/mJXQGYXmG7UUyWEG+KCJusayIAQLywUjFAskDoKuxfqVnGF+M/mTMrEV8J64DaIdU+5x761FvgmT7M68tA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-http1": "^4.4.0",
+        "bare-tcp": "^2.2.0",
+        "bare-tls": "^2.0.0"
+      }
+    },
+    "node_modules/bare-inspect": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/bare-inspect/-/bare-inspect-3.1.4.tgz",
+      "integrity": "sha512-jfW5KRA84o3REpI6Vr4nbvMn+hqVAw8GU1mMdRwUsY5yJovQamxYeKGVKGqdzs+8ZbG4jRzGUXP/3Ji/DnqfPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-ansi-escapes": "^2.1.0",
+        "bare-type": "^1.0.0"
+      },
+      "engines": {
+        "bare": ">=1.18.0"
+      }
+    },
+    "node_modules/bare-inspector": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bare-inspector/-/bare-inspector-4.0.3.tgz",
+      "integrity": "sha512-yYk6+7tTVKJKHOja5+QBn989ETv8oVsmwoH0nCM+QYC6w5MC03GC4aQNK+lipAZSz1EaAj42WZ8Wewjpy0L9TA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.1.0",
+        "bare-http1": "^4.0.0",
+        "bare-stream": "^2.0.0",
+        "bare-url": "^2.0.0",
+        "bare-ws": "^2.0.0"
+      },
+      "engines": {
+        "bare": ">=1.2.0"
+      },
+      "peerDependencies": {
+        "bare-tcp": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-tcp": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-module": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/bare-module/-/bare-module-6.2.0.tgz",
+      "integrity": "sha512-CoCTG8y8HKPnNW317OW1hynl28DasVPtbX033ZEAXk0Q3SYCUXi3OOnNAr6wTrDgMgpOsW0kl7Nifcom5GGH8Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-bundle": "^1.3.0",
+        "bare-module-lexer": "^1.0.0",
+        "bare-module-resolve": "^1.8.0",
+        "bare-path": "^3.0.0",
+        "bare-url": "^2.0.1"
+      },
+      "engines": {
+        "bare": ">=1.23.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-module-lexer": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/bare-module-lexer/-/bare-module-lexer-1.4.7.tgz",
+      "integrity": "sha512-0klU4eMsjh/wcxi8FdHmNom2j2F4kmkXOhyJFL9qTaSFp2lE3m6BtbKgMHY8R5miqC9r8/IfA8wzXnC5Os14WA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "require-addon": "^1.0.2"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-module-resolve": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.1.tgz",
+      "integrity": "sha512-hbmAPyFpEq8FoZMd5sFO3u6MC5feluWoGE8YKlA8fCrl6mNtx68Wjg4DTiDJcqRJaovTvOYKfYngoBUnbaT7eg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-net": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/bare-net/-/bare-net-2.3.1.tgz",
+      "integrity": "sha512-MypSqDKpDU2Xt7FIfazn5yGvRnV09gFcIPHGWstW0gxuzA4tucTcwJSZeos97C4F89vtU5oGwXDN/HrGN6Y4Jw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.2.2",
+        "bare-pipe": "^4.0.0",
+        "bare-stream": "^2.0.0",
+        "bare-tcp": "^2.0.0"
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+      "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-pipe": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/bare-pipe/-/bare-pipe-4.1.5.tgz",
+      "integrity": "sha512-6OfxaG8JSkRh3Gc4hzHRsxNt+yu2PpN7lrv1V+T78GdknWQkVGwiEvu4m+1nbfk8cMVQ0TGxRvQ90XA4rhnTuw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.0.0",
+        "bare-stream": "^2.0.0"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
+    "node_modules/bare-process": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/bare-process/-/bare-process-4.4.1.tgz",
+      "integrity": "sha512-JfcTtymq6akqM2bdyTsP4A4GYJceBzb91k/ECmFps75uFf6uO33SM1bOZsRAqyRXExabsQJLn5S41NBl8HTM4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-abort": "^2.0.13",
+        "bare-env": "^3.0.0",
+        "bare-events": "^2.3.1",
+        "bare-hrtime": "^2.0.0",
+        "bare-os": "^3.7.1",
+        "bare-signals": "^4.0.0",
+        "bare-stdio": "^1.0.1"
+      }
+    },
+    "node_modules/bare-semver": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.0.3.tgz",
+      "integrity": "sha512-HS/A30bi2+PiRJfU6R4+Kp+6KeLSCSByjYM2iiobOKzLAvtu1CT+S8xWfiU7wz0erknjkUoC+yXy108tzIuP5Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-signals": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/bare-signals/-/bare-signals-4.2.0.tgz",
+      "integrity": "sha512-fNHMOdQIlYuTvMB3Oh9Apk99hLKn351+Ir8vz+khiPTcOqIyGG4uWWjdLTzxWdYGsA0eT+We3y0K74hjj2nq7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.3",
+        "bare-os": "^3.3.1"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
+      }
+    },
+    "node_modules/bare-stdio": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bare-stdio/-/bare-stdio-1.0.2.tgz",
+      "integrity": "sha512-3WJDqtvVGP4f+j68kyEC05umOYNwKJ1xG+YAXL8yZ605WgNqiRhVaFq+mVIhBt2eKNp7pa5vCQdhOt1pNh79SA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.5.2",
+        "bare-pipe": "^4.1.5",
+        "bare-tty": "^5.0.3"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-stylize": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/bare-stylize/-/bare-stylize-0.0.1.tgz",
+      "integrity": "sha512-l3MjmIl476bWijYWf3RbE+osl4iuXSOMudzp0vAqzIK7gPgn/+G3oAxp8Oin9CFF911KBP0LO9kts8Ci8mGZaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-ansi-escapes": "^2.2.3",
+        "bare-process": "^4.2.1"
+      }
+    },
+    "node_modules/bare-subprocess": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-5.2.3.tgz",
+      "integrity": "sha512-07wwswlV7M3sC9IykbZRZ/jHAkrXFWVLqdBWGv1y0ojCimtRD9hGwxdHmR5FUFmDUZLNsBmTYJNQqgio5+A85Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-env": "^3.0.0",
+        "bare-events": "^2.5.4",
+        "bare-os": "^3.0.1",
+        "bare-pipe": "^4.0.0",
+        "bare-url": "^2.2.2"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-tcp": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/bare-tcp/-/bare-tcp-2.2.7.tgz",
+      "integrity": "sha512-rjpqNQ2cOCkNo3NeYA/W4GTK3DRkl8sDHO3uos+AEswUjLC8XXMQF8WrJCSjlIowCbS6NUVxKE92X5RGXjyefg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-dns": "^2.0.4",
+        "bare-events": "^2.5.4",
+        "bare-stream": "^2.6.4"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
+    "node_modules/bare-tls": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/bare-tls/-/bare-tls-2.2.3.tgz",
+      "integrity": "sha512-dPYBGEXtgLceRFMfGaF2/rqR86/xMxMyrM9ootO/gaRKL/z2uNHJs7aP7IOBtnJF8eUCt5qwMzbKfrKgDIxPLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-net": "^2.0.1",
+        "bare-stream": "^2.6.4"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
+      }
+    },
+    "node_modules/bare-tty": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bare-tty/-/bare-tty-5.1.0.tgz",
+      "integrity": "sha512-EZLvW4A+XiJgI3TW+e1pMME9PIJsfEXe/DA/WSKzIkq/v7Yarpv/rvG6Z5pGnpo4V/Bd+qopwnCLSR71hMMBYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.2.0",
+        "bare-signals": "^4.0.0",
+        "bare-stream": "^2.0.0"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
+    "node_modules/bare-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-type/-/bare-type-1.1.0.tgz",
+      "integrity": "sha512-LdtnnEEYldOc87Dr4GpsKnStStZk3zfgoEMXy8yvEZkXrcCv9RtYDrUYWFsBQHtaB0s1EUWmcvS6XmEZYIj3Bw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.2.0"
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+      "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/bare-utils": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/bare-utils/-/bare-utils-1.6.0.tgz",
+      "integrity": "sha512-WhQEIkkAxkSnW7u1QgrI0AfNm5JpMruETXeYsb5qnkBJ0TTfNKygZmsh6rkoHBANaV+C/7Jed7bJP9OmEHG7rQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-debug-log": "^2.0.0",
+        "bare-encoding": "^1.0.0",
+        "bare-format": "^1.0.0",
+        "bare-inspect": "^3.0.0",
+        "bare-stylize": "^0.0.1",
+        "bare-type": "^1.0.6"
+      }
+    },
+    "node_modules/bare-v8-to-istanbul": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bare-v8-to-istanbul/-/bare-v8-to-istanbul-1.0.2.tgz",
+      "integrity": "sha512-CM0wPgyQtXTQ7h4q8NjbTZ/FH5he0Jkiwgpq0lFZZA5tkVZzmQ/9ul4R7E+cNlGZJIZlQZ9v4CwbgVaFG3zOAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-assert": "^1.0.2",
+        "bare-fs": "^4.1.2",
+        "bare-module": "^6.1.2",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.2.0",
+        "bare-url": "^2.1.5",
+        "bare-utils": "^1.2.0",
+        "v8-to-istanbul": "^9.3.0",
+        "which-runtime": "^1.2.1"
+      }
+    },
+    "node_modules/bare-ws": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bare-ws/-/bare-ws-2.1.0.tgz",
+      "integrity": "sha512-2gEWlPK9iyBchACdIY6oQXgmDz3KLrChdwrPgmU3IVXOFTnxTqSUT27WE/+izd4QojHj/SsqDkQiD2HDvuTdAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-crypto": "^1.2.0",
+        "bare-events": "^2.3.1",
+        "bare-http1": "^4.0.0",
+        "bare-https": "^2.0.0",
+        "bare-stream": "^2.1.2"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-url": {
+          "optional": true
+        }
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -428,6 +1117,36 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/brittle": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/brittle/-/brittle-3.19.1.tgz",
+      "integrity": "sha512-4Ted1Mt9o9B6oIA6ImJJCtB/Fv++ZO3IDNQgRcHOXWSYGRUidgxchaGrUBaRn+4mlneXrgInPkCPzi0jO8qKbA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.0",
+        "bare-assert": "^1.0.2",
+        "bare-cov": "^1.1.0",
+        "bare-fs": "^4.1.6",
+        "bare-os": "^3.6.1",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.2.1",
+        "bare-subprocess": "^5.0.0",
+        "bare-url": "^2.1.6",
+        "error-stack-parser": "^2.1.4",
+        "globbie": "^1.0.2",
+        "paparam": "^1.6.2",
+        "same-object": "^1.0.2",
+        "test-tmp": "^1.4.0",
+        "tmatch": "^5.0.0"
+      },
+      "bin": {
+        "brittle": "bin/node.js",
+        "brittle-bare": "bin/bare.js",
+        "brittle-node": "bin/node.js",
+        "brittle-pear": "bin/pear.js"
       }
     },
     "node_modules/builtins": {
@@ -546,6 +1265,13 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -702,6 +1428,16 @@
       "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
       }
     },
     "node_modules/es-abstract": {
@@ -1364,11 +2100,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -1635,6 +2388,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globbie": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globbie/-/globbie-1.0.3.tgz",
+      "integrity": "sha512-hcryJmKcftf82xfBWTWxuUITWIIoYO3ec104V17SMHGFl6VLbm1d1Ju9LX9L+jyJTwICpemX/dmPI/HGYoKr1A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-fs": "^4.1.2",
+        "bare-path": "^3.0.0",
+        "bare-process": "^4.2.1",
+        "picomatch": "^4.0.2"
       }
     },
     "node_modules/gopd": {
@@ -2608,6 +3374,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/paparam": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/paparam/-/paparam-1.10.1.tgz",
+      "integrity": "sha512-viyQI64VIja0Za3njIzhoEP8ZVkgPowhZPuG0E96NwBfYJ6ZIyrrlhWGtFPkdN7eYLl2L8CTWL+wla0evm1KKQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2665,6 +3438,19 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/pify": {
       "version": "4.0.1",
@@ -2867,6 +3653,19 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/require-addon": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz",
+      "integrity": "sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-addon-resolve": "^1.3.0"
+      },
+      "engines": {
+        "bare": ">=1.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -2996,6 +3795,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/same-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/same-object/-/same-object-1.0.2.tgz",
+      "integrity": "sha512-csHWhvUsLbIOHDM/nP+KHWM+BLPsIzWkFa8HbzaI0G7BqKXgx+7FJpKTGgLXyz5amfdY2OVBcmXTqYOMEk04og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -3145,6 +3951,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/standard": {
       "version": "17.1.2",
       "resolved": "https://registry.npmjs.org/standard/-/standard-17.1.2.tgz",
@@ -3222,6 +4035,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -3374,11 +4199,53 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/test-tmp": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/test-tmp/-/test-tmp-1.4.0.tgz",
+      "integrity": "sha512-GVggxGg+jXqP2Wbju50JVLo+9E+nIOPPyWqgr63EbOnNItIKu1cEbJpTWAJeflnyGqXOtcMI7ijHRp88GUkfDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-os": "^3.3.0",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/tmatch": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-5.0.0.tgz",
+      "integrity": "sha512-Ib9OtBkpHn07tXP04SlN1SYRxFgTk6wSM2EBmjjxug4u5RXPRVLkdFJSS1PmrQidaSB8Lru9nRtViQBsbxzE5Q==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -3517,6 +4384,21 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/version-guard": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/version-guard/-/version-guard-1.1.3.tgz",
@@ -3604,6 +4486,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-runtime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/which-runtime/-/which-runtime-1.3.2.tgz",
+      "integrity": "sha512-5kwCfWml7+b2NO7KrLMhYihjRx0teKkd3yGp1Xk5Vaf2JGdSh+rgVhEALAD9c/59dP+YwJHXoEO7e8QPy7gOkw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/which-typed-array": {
       "version": "1.1.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitfinex/bfx-facs-base",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": false,
   "description": "Bitfinex base facility",
   "scripts": {
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "async": "^3.2.1",
-    "lodash": "^4.17.21"
+    "lodash": "^4.18.1"
   },
   "devDependencies": {
     "brittle": "^3.19.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "description": "Bitfinex base facility",
   "scripts": {
     "lint": "standard",
-    "lint:fix": "standard --fix"
+    "lint:fix": "standard --fix",
+    "test": "npm run lint && npm run test:unit",
+    "test:unit": "brittle tests/{,**/}*.test.js"
   },
   "author": {
     "name": "prdn",
@@ -19,7 +21,9 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "standard": "^17.1.2"
+    "brittle": "^3.19.1",
+    "standard": "^17.1.2",
+    "test-tmp": "^1.4.0"
   },
   "engines": {
     "node": ">=16.0"

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -1,0 +1,113 @@
+'use strict'
+
+const { test } = require('brittle')
+const tmp = require('test-tmp')
+const path = require('path')
+const fs = require('fs')
+
+const Facility = require('../base')
+
+function createFacility (dir, env) {
+  const caller = { ctx: { root: dir } }
+  const fac = new Facility(caller, {}, { env })
+  fac._hasConf = true
+  return fac
+}
+
+async function setupDir (t) {
+  const dir = await tmp(t)
+  fs.mkdirSync(path.join(dir, 'config', 'facs'), { recursive: true })
+  return dir
+}
+
+function writeConfig (dir, filename, content) {
+  const filePath = path.join(dir, 'config', 'facs', filename)
+  const data = filename.endsWith('.js') ? content : JSON.stringify(content)
+  fs.writeFileSync(filePath, data)
+}
+
+test('JSON config resolution', async (t) => {
+  await t.test('loads base JSON config if env is not provided', async (t) => {
+    const dir = await setupDir(t)
+    writeConfig(dir, 'facility.config.json', { facility: { key: 'value' } })
+    writeConfig(dir, 'production.facility.config.json', { facility: { key: 'env-specific' } })
+
+    const fac = createFacility(dir)
+    fac.init()
+    t.alike(fac.conf, { key: 'value' })
+  })
+
+  await t.test('loads env-specific JSON config over base others', async (t) => {
+    const dir = await setupDir(t)
+    writeConfig(dir, 'facility.config.json', { facility: { key: 'base' } })
+    writeConfig(dir, 'production.facility.config.json', { facility: { key: 'prod-env-specific' } })
+    writeConfig(dir, 'development.facility.config.json', { facility: { key: 'dev-env-specific' } })
+
+    const fac = createFacility(dir, 'production')
+    fac.init()
+    t.is(fac.conf.key, 'prod-env-specific')
+  })
+
+  await t.test('falls back to base JSON if env-specific JSON is missing', async (t) => {
+    const dir = await setupDir(t)
+    writeConfig(dir, 'facility.config.json', { facility: { key: 'base' } })
+
+    const fac = createFacility(dir, 'production')
+    fac.init()
+    t.is(fac.conf.key, 'base')
+  })
+})
+
+test('JS config resolution', async (t) => {
+  await t.test('loads base JS config when no JSON exists', async (t) => {
+    const dir = await setupDir(t)
+    writeConfig(dir, 'facility.config.js', "module.exports = { facility: { key: 'from-js' } }")
+
+    const fac = createFacility(dir)
+    fac.init()
+    t.is(fac.conf.key, 'from-js')
+  })
+
+  await t.test('loads env-specific JS config when no JSON exists and env is provided', async (t) => {
+    const dir = await setupDir(t)
+    writeConfig(dir, 'development.facility.config.js', "module.exports = { facility: { key: 'dev-env-js' } }")
+    writeConfig(dir, 'production.facility.config.js', "module.exports = { facility: { key: 'prod-js' } }")
+
+    const fac = createFacility(dir, 'development')
+    fac.init()
+    t.is(fac.conf.key, 'dev-env-js')
+  })
+
+  await t.test('falls back to base JS if env-specific JS is missing and no JSON exists', async (t) => {
+    const dir = await setupDir(t)
+    writeConfig(dir, 'facility.config.js', "module.exports = { facility: { key: 'base-js' } }")
+
+    const fac = createFacility(dir, 'production')
+    fac.init()
+    t.is(fac.conf.key, 'base-js')
+  })
+})
+
+test('config priority order', async (t) => {
+  await t.test('JSON config takes priority over JS config', async (t) => {
+    const dir = await setupDir(t)
+    writeConfig(dir, 'facility.config.json', { facility: { source: 'json' } })
+    writeConfig(dir, 'facility.config.js', "module.exports = { facility: { source: 'js' } }")
+
+    const fac = createFacility(dir)
+    fac.init()
+    t.is(fac.conf.source, 'json')
+  })
+
+  await t.test('env-specific JSON has highest priority', async (t) => {
+    const dir = await setupDir(t)
+    writeConfig(dir, 'production.facility.config.json', { facility: { source: 'env-json' } })
+    writeConfig(dir, 'facility.config.json', { facility: { source: 'base-json' } })
+    writeConfig(dir, 'production.facility.config.js', "module.exports = { facility: { source: 'env-js' } }")
+    writeConfig(dir, 'facility.config.js', "module.exports = { facility: { source: 'base-js' } }")
+
+    const fac = createFacility(dir, 'production')
+    fac.init()
+    t.is(fac.conf.source, 'env-json')
+  })
+})


### PR DESCRIPTION
## Summary
- Extends config loading to support both JSON and JS config files
- JSON files take priority over JS files
- Maintains backward compatibility with existing JSON configs

## Priority order
1. `{env}.{name}.config.json`
2. `{name}.config.json`
3. `{env}.{name}.config.js`
4. `{name}.config.js`

## Usage
JS config files should export an object with namespace keys:
```javascript
module.exports = {
  namespace1: { /* config */ },
  namespace2: { /* config */ }
}
```